### PR TITLE
Add a Multi Architecture CodePipeline Example

### DIFF
--- a/soci-codepipeline/README.md
+++ b/soci-codepipeline/README.md
@@ -179,7 +179,7 @@ You can create a Docker manifest list in a CodeBuild container based builder
 with the `docker manifest`
 [docs](https://docs.docker.com/engine/reference/commandline/manifest/) or
 `docker buildx imagetools`
-([[docs](https://docs.docker.com/engine/reference/commandline/buildx_imagetools/)]).
+([docs](https://docs.docker.com/engine/reference/commandline/buildx_imagetools/)).
 There is a great example
 [here](https://github.com/aws-samples/aws-multiarch-container-build-pipeline/blob/b1060d397751b1c9113a2c1c86c2d5565faa5f85/lib/build-manifest.ts#L70)
 using `docker manifest`.

--- a/soci-codepipeline/README.md
+++ b/soci-codepipeline/README.md
@@ -77,10 +77,10 @@ You can deploy the AWS CodePipeline in your AWS Account with the following steps
    }
    ```
 
-## Walkthrough of the buildspec file
+### Walkthrough of the buildspec file
 
 The [buildspec file](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) file for CodeBuild can be be found in the cloudformation template,
-however in this `README.md` I have added some commentary.
+however in this `README.md` we have added some commentary.
 
 **Pre Build**
 
@@ -116,7 +116,7 @@ Steps defined in the buildspec file:
 1. Leveraging Moby's [buildkit](https://github.com/moby/buildkit) (exposed by
    `docker buildx`) we build the container image. There are a number of
    [exporters](https://docs.docker.com/build/exporters/) for buildkit, but given
-   that the end result we want is a tarball, I decided to use a
+   that the end result we want is a tarball, we decided to use a
    `docker-container` builder because it can export directly to an `.tar`. I'm
    also leveraging a `type=oci` so that my container image conforms to the OCI
    v1 spec, but this is not mandatory, and `type=docker` (the Docker v2.2 spec)
@@ -155,3 +155,69 @@ Steps defined in the buildspec file:
     - echo Push the SOCI index to ECR
     - soci push --user AWS:$PASSWORD $IMAGE_URI:$IMAGE_TAG
     ```
+
+## Building a Multi Architecture Pipeline
+
+When building container images it is common to build for both x86 and arm64
+architectures at the same time. While you could build arm64 container images on
+x86 hosts through emulation, it is a lot more performant to natively build arm64
+images on arm64 hosts. Therefore we have included an example CodePipeline that
+will concurrently build two container images, one x86 image, one arm64 image in
+separate CodeBuild jobs on the native architectures.
+
+After both container images have been built, we then need to create a [Docker
+manifest list](https://distribution.github.io/distribution/#manifest-list) (or
+an [OCI image
+index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)).
+This additional metadata file is used as a signpost by the container runtime
+when deciding which container image to use. I.e. a container runtime on a x86
+host, will read the manifest list to discover the image digest for the x86
+image. Once its retrieved the x86 container image digest, it will go and
+download that image from the repository.
+
+You can create a Docker manifest list in a CodeBuild container based builder
+with the `docker manifest`
+[docs](https://docs.docker.com/engine/reference/commandline/manifest/) or
+`docker buildx imagetools`
+([[docs](https://docs.docker.com/engine/reference/commandline/buildx_imagetools/)]).
+There is a great example
+[here](https://github.com/aws-samples/aws-multiarch-container-build-pipeline/blob/b1060d397751b1c9113a2c1c86c2d5565faa5f85/lib/build-manifest.ts#L70)
+using `docker manifest`.
+
+However in our example we have leveraged the new [CodeBuild Lambda based builder](https://aws.amazon.com/about-aws/whats-new/2023/11/aws-codebuild-lambda-compute/),
+to build the manifest list using the `manifest-tool` cli
+([source](https://github.com/estesp/manifest-tool)).
+
+To deploy the multi architecture pipeline:
+
+```bash
+aws cloudformation \
+    create-stack \
+    --stack-name soci-multi-arch-pipeline \
+    --template-body file://multiarch-cloudformation.yaml \
+    --capabilities CAPABILITY_IAM
+```
+
+### Buildx work around
+
+There is a difference in the [CodeBuild Amazon Linux
+images](https://github.com/aws/aws-codebuild-docker-images) for x86 and arm64.
+The arm64 image [does not include docker
+buildx](https://github.com/aws/aws-codebuild-docker-images/issues/640),
+therefore the [method](#walkthrough-of-the-buildspec-file) used in our x86
+buildspec file can not be reused.
+
+Instead we build the container image using `docker build`, and then export the
+container image out of the Docker Engine image store with `docker save`, ready
+to be imported into the containerd image store. Importing into the containerd
+image store and generating the SOCI index is identical to the x86 buildspec
+file.
+
+Snippet from the arm64 buildspec file
+
+```yaml
+- echo Building the container image
+- docker build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 .
+- echo Export the container image
+- docker save --output ./image.tar $IMAGE_URI:$IMAGE_TAG
+```

--- a/soci-codepipeline/multiarch-cloudformation.yaml
+++ b/soci-codepipeline/multiarch-cloudformation.yaml
@@ -1,0 +1,488 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Build a multiarch container image with SOCI Indexes on AWS CodeBuild
+
+Parameters:
+  RepositoryName:
+    Description: Name of the Codecommit and ECR Repositories
+    Type: String
+    Default: socidemoapp
+  SociVersion:
+    Description: Version of the SOCI cli to use
+    Type: String
+    Default: 0.4.1
+
+Resources:
+  ######################
+  # Core AWS Resources #
+  ######################
+  CodeRepo:
+    Type: AWS::CodeCommit::Repository
+    Properties:
+      RepositoryName: !Ref RepositoryName
+
+  DemoAppEcr:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Ref RepositoryName
+
+  SourceBucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
+
+  ####################################################
+  # Cloudwatch Event to Trigger CodePipeline on Push #
+  ####################################################
+  AmazonCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: cwe-pipeline-execution
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}'
+
+  AmazonCloudWatchEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.codecommit
+        detail-type:
+          - 'CodeCommit Repository State Change'
+        resources:
+          - !Sub 'arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${RepositoryName}'
+        detail:
+          event:
+            - referenceCreated
+            - referenceUpdated
+          referenceType:
+            - branch
+          referenceName:
+            - main
+      Targets:
+        - Arn: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}'
+          RoleArn: !GetAtt AmazonCloudWatchEventRole.Arn
+          Id: codepipeline-Pipeline
+
+  ############################
+  # Pipeline IAM Permissions #
+  ############################
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+        Version: "2012-10-17"
+
+  PipelineRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: PipelineRoleDefaultPolicy
+      Roles:
+        - Ref: PipelineRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - !GetAtt SourceBucket.Arn
+              - !Sub "${SourceBucket.Arn}/*"
+          - Action:
+              - codebuild:StartBuild
+              - codebuild:BatchGetBuilds
+            Effect: Allow
+            Resource:
+              - !GetAtt ImageBuildx86.Arn
+              - !GetAtt ImageBuildArm64.Arn
+              - !GetAtt DockerManifestList.Arn
+          - Action:
+              - codecommit:GetRepository
+              - codecommit:GetBranch
+              - codecommit:GetCommit
+            Effect: Allow
+            Resource:
+              - !GetAtt CodeRepo.Arn
+
+  ################################
+  # Build the Image in CodeBuild #
+  ################################
+  ImageBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+
+  ImageBuildRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ImageBuildRoleDefaultPolicy
+      Roles:
+        - Ref: ImageBuildRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ImageBuildx86}:*"
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ImageBuildArm64}:*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:PutObject*
+            Effect: Allow
+            Resource:
+              - !GetAtt SourceBucket.Arn
+              - !Sub "${SourceBucket.Arn}/*"
+          - Action:
+              - codecommit:GitPull
+            Effect: Allow
+            Resource:
+              - !GetAtt CodeRepo.Arn
+          - Action:
+              - ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource:
+              - "*"
+          - Action:
+              - ecr:BatchGetImage
+              - ecr:BatchCheckLayerAvailability
+              - ecr:CompleteLayerUpload
+              - ecr:InitiateLayerUpload
+              - ecr:PutImage
+              - ecr:UploadLayerPart
+            Effect: Allow
+            Resource:
+              - !GetAtt DemoAppEcr.Arn
+
+  # x86 CodeBuild image has Buildx installed
+  ImageBuildx86:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${AWS::StackName}-ImageBuild-x86"
+      Artifacts:
+        Type: CODEPIPELINE
+        EncryptionDisabled: false
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: CONTAINERD_ADDRESS
+            Type: PLAINTEXT
+            Value: "/var/run/docker/containerd/containerd.sock"
+      ServiceRole: !Ref ImageBuildRole
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - echo Download the SOCI Binaries
+                - wget --quiet https://github.com/awslabs/soci-snapshotter/releases/download/v${SociVersion}/soci-snapshotter-${SociVersion}-linux-amd64.tar.gz
+                - tar xvzf soci-snapshotter-${SociVersion}-linux-amd64.tar.gz soci
+                - mv soci /usr/local/bin/soci
+                - echo Logging in to Amazon ECR...
+                - export PASSWORD=$(aws ecr get-login-password --region ${AWS::Region})
+            build:
+              commands:
+                - cd api/
+                - echo Building the container image
+                - docker buildx create --driver=docker-container --use
+                - docker buildx build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 --output type=docker,dest=./image.tar .
+                - echo Import the container image to containerd
+                - ctr image import ./image.tar
+                - echo Generating SOCI index
+                - soci create $IMAGE_URI:$IMAGE_TAG
+                - echo Pushing the container image
+                - ctr image push --user AWS:$PASSWORD $IMAGE_URI:$IMAGE_TAG
+                - echo Push the SOCI index to ECR
+                - soci push --user AWS:$PASSWORD $IMAGE_URI:$IMAGE_TAG
+
+  # ARM CodeBuild image does not Buildx installed
+  ImageBuildArm64:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${AWS::StackName}-ImageBuild-arm64"
+      Artifacts:
+        Type: CODEPIPELINE
+        EncryptionDisabled: false
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0
+        PrivilegedMode: true
+        Type: ARM_CONTAINER
+        EnvironmentVariables:
+          - Name: CONTAINERD_ADDRESS
+            Type: PLAINTEXT
+            Value: "/var/run/docker/containerd/containerd.sock"
+      ServiceRole: !Ref ImageBuildRole
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - echo Download the SOCI Binaries
+                - wget --quiet https://github.com/awslabs/soci-snapshotter/releases/download/v${SociVersion}/soci-snapshotter-${SociVersion}-linux-arm64.tar.gz
+                - tar xvzf soci-snapshotter-${SociVersion}-linux-arm64.tar.gz soci
+                - mv soci /usr/local/bin/soci
+                - echo Logging in to Amazon ECR...
+                - export PASSWORD=$(aws ecr get-login-password --region ${AWS::Region})
+            build:
+              commands:
+                - cd api/
+                - echo Building the container image
+                - docker build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 .
+                - echo Export the container image
+                - docker save --output ./image.tar $IMAGE_URI:$IMAGE_TAG
+                - echo Import the container image to containerd
+                - ctr image import ./image.tar
+                - echo Generating SOCI index
+                - soci create $IMAGE_URI:$IMAGE_TAG
+                - echo Pushing the container image
+                - ctr image push --user AWS:$PASSWORD $IMAGE_URI:$IMAGE_TAG
+                - echo Push the SOCI index to ECR
+                - soci push --user AWS:$PASSWORD $IMAGE_URI:$IMAGE_TAG
+
+  #################################
+  # Create a Docker Manifest List #
+  #################################
+  DockerManifestListRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+
+  DockerManifestListRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: DockerManifestListRolePolicy
+      Roles:
+        - Ref: DockerManifestListRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${DockerManifestList}:*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:PutObject*
+            Effect: Allow
+            Resource:
+              - !GetAtt SourceBucket.Arn
+              - !Sub "${SourceBucket.Arn}/*"
+          - Action:
+              - codecommit:GitPull
+            Effect: Allow
+            Resource:
+              - !GetAtt CodeRepo.Arn
+          - Action:
+              - ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource:
+              - "*"
+          - Action:
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+              - ecr:PutImage
+            Effect: Allow
+            Resource:
+              - !GetAtt DemoAppEcr.Arn
+
+  DockerManifestList:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${AWS::StackName}-DockerManifestList"
+      Artifacts:
+        Type: CODEPIPELINE
+        EncryptionDisabled: false
+      Environment:
+        ComputeType: BUILD_LAMBDA_1GB
+        Image: aws/codebuild/amazonlinux-aarch64-lambda-standard:go1.21
+        Type: ARM_LAMBDA_CONTAINER
+        EnvironmentVariables:
+          - Name: DOCKER_CONFIG
+            Type: PLAINTEXT
+            Value: "/tmp/.docker/"
+      ServiceRole: !Ref DockerManifestListRole
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - mkdir /tmp/.docker
+                - >
+                  echo '{"credsStore": "ecr-login"}' > /tmp/.docker/config.json
+                - echo Install Credential Helper
+                - GOSUMDB=off go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
+                - echo Install manifest tool
+                - GOSUMDB=off go install github.com/estesp/manifest-tool/v2/cmd/manifest-tool@latest
+            build:
+              commands:
+                - manifest-tool push from-args --platforms linux/amd64,linux/arm64 --template $IMAGE_URI:$IMAGE_TAG-ARCH --target $IMAGE_URI:$IMAGE_TAG
+
+  #######################
+  # Define CodePipeline #
+  #######################
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    DependsOn:
+         - PipelineRoleDefaultPolicy
+    Properties:
+      ArtifactStore:
+        Type: S3
+        Location: !Ref "SourceBucket"
+      RoleArn:
+        Fn::GetAtt:
+          - PipelineRole
+          - Arn
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: GitRepo
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeCommit
+                Version: "1"
+              Configuration:
+                RepositoryName: !GetAtt CodeRepo.Name
+                BranchName: "main"
+                PollForSourceChanges: false
+                OutputArtifactFormat: CODEBUILD_CLONE_REF
+              OutputArtifacts:
+                - Name: SourceArtifact
+        - Name: Build
+          Actions:
+            - Name: BuildContainerImagex86
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: !Ref ImageBuildx86
+                EnvironmentVariables: !Sub |
+                  [
+                    {
+                      "name": "IMAGE_URI",
+                      "value": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DemoAppEcr}",
+                      "type": "PLAINTEXT"
+                    },
+                    {
+                      "name": "IMAGE_TAG",
+                      "value": "#{codepipeline.PipelineExecutionId}-amd64",
+                      "type": "PLAINTEXT"
+                    }
+                  ]
+              InputArtifacts:
+                - Name: SourceArtifact
+            - Name: BuildContainerImageArm64
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: !Ref ImageBuildArm64
+                EnvironmentVariables: !Sub |
+                  [
+                    {
+                      "name": "IMAGE_URI",
+                      "value": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DemoAppEcr}",
+                      "type": "PLAINTEXT"
+                    },
+                    {
+                      "name": "IMAGE_TAG",
+                      "value": "#{codepipeline.PipelineExecutionId}-arm64",
+                      "type": "PLAINTEXT"
+                    }
+                  ]
+              InputArtifacts:
+                - Name: SourceArtifact
+        - Name: CreateManifestList
+          Actions:
+            - Name: CreateManifestList
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: !Ref DockerManifestList
+                EnvironmentVariables: !Sub |
+                  [
+                    {
+                      "name": "IMAGE_URI",
+                      "value": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DemoAppEcr}",
+                      "type": "PLAINTEXT"
+                    },
+                    {
+                      "name": "IMAGE_TAG",
+                      "value": "#{codepipeline.PipelineExecutionId}",
+                      "type": "PLAINTEXT"
+                    }
+                  ]
+              InputArtifacts:
+                - Name: SourceArtifact
+
+
+Outputs:
+  DemoAppEcr:
+    Description: ECR Repository to store the Demo App Image
+    Value: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DemoAppEcr}"
+  DemoAppEcrName:
+    Description: ECR Repository to store the Demo App Image
+    Value: !Ref DemoAppEcr


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a multi architecture CodePipeline example. This pipeline:

- Builds the x86 image using `docker buildx`
- Builds the arm64 image using `docker build`
- Creates a Docker manifest list using `manifest-tool`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
