### PR TITLE
Bump CodeBuild Examples

### DIFF
--- a/soci-codepipeline/README.md
+++ b/soci-codepipeline/README.md
@@ -184,7 +184,8 @@ There is a great example
 [here](https://github.com/aws-samples/aws-multiarch-container-build-pipeline/blob/b1060d397751b1c9113a2c1c86c2d5565faa5f85/lib/build-manifest.ts#L70)
 using `docker manifest`.
 
-However in our example we have leveraged the new [CodeBuild Lambda based builder](https://aws.amazon.com/about-aws/whats-new/2023/11/aws-codebuild-lambda-compute/),
+However in our example we have leveraged the new [CodeBuild Lambda based
+builder](https://aws.amazon.com/about-aws/whats-new/2023/11/aws-codebuild-lambda-compute/),
 to build the manifest list using the `manifest-tool` cli
 ([source](https://github.com/estesp/manifest-tool)).
 
@@ -196,28 +197,4 @@ aws cloudformation \
     --stack-name soci-multi-arch-pipeline \
     --template-body file://multiarch-cloudformation.yaml \
     --capabilities CAPABILITY_IAM
-```
-
-### Buildx work around
-
-There is a difference in the [CodeBuild Amazon Linux
-images](https://github.com/aws/aws-codebuild-docker-images) for x86 and arm64.
-The arm64 image [does not include docker
-buildx](https://github.com/aws/aws-codebuild-docker-images/issues/640),
-therefore the [method](#walkthrough-of-the-buildspec-file) used in our x86
-buildspec file can not be reused.
-
-Instead we build the container image using `docker build`, and then export the
-container image out of the Docker Engine image store with `docker save`, ready
-to be imported into the containerd image store. Importing into the containerd
-image store and generating the SOCI index is identical to the x86 buildspec
-file.
-
-Snippet from the arm64 buildspec file
-
-```yaml
-- echo Building the container image
-- docker build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 .
-- echo Export the container image
-- docker save --output ./image.tar $IMAGE_URI:$IMAGE_TAG
 ```

--- a/soci-codepipeline/cloudformation.yaml
+++ b/soci-codepipeline/cloudformation.yaml
@@ -9,7 +9,7 @@ Parameters:
   SociVersion:
     Description: Version of the SOCI cli to use
     Type: String
-    Default: 0.4.1
+    Default: 0.5.0
 
 Resources:
   ######################
@@ -212,7 +212,7 @@ Resources:
               commands:
                 - echo Download the SOCI Binaries
                 - wget --quiet https://github.com/awslabs/soci-snapshotter/releases/download/v${SociVersion}/soci-snapshotter-${SociVersion}-linux-amd64.tar.gz
-                - tar xvzf soci-snapshotter-${SociVersion}-linux-amd64.tar.gz soci
+                - tar xvzf soci-snapshotter-${SociVersion}-linux-amd64.tar.gz ./soci
                 - mv soci /usr/local/bin/soci
                 - echo Logging in to Amazon ECR...
                 - export PASSWORD=$(aws ecr get-login-password --region ${AWS::Region})

--- a/soci-codepipeline/multiarch-cloudformation.yaml
+++ b/soci-codepipeline/multiarch-cloudformation.yaml
@@ -9,7 +9,7 @@ Parameters:
   SociVersion:
     Description: Version of the SOCI cli to use
     Type: String
-    Default: 0.4.1
+    Default: 0.5.0
 
 Resources:
   ######################
@@ -216,7 +216,7 @@ Resources:
               commands:
                 - echo Download the SOCI Binaries
                 - wget --quiet https://github.com/awslabs/soci-snapshotter/releases/download/v${SociVersion}/soci-snapshotter-${SociVersion}-linux-amd64.tar.gz
-                - tar xvzf soci-snapshotter-${SociVersion}-linux-amd64.tar.gz soci
+                - tar xvzf soci-snapshotter-${SociVersion}-linux-amd64.tar.gz ./soci
                 - mv soci /usr/local/bin/soci
                 - echo Logging in to Amazon ECR...
                 - export PASSWORD=$(aws ecr get-login-password --region ${AWS::Region})
@@ -262,7 +262,7 @@ Resources:
               commands:
                 - echo Download the SOCI Binaries
                 - wget --quiet https://github.com/awslabs/soci-snapshotter/releases/download/v${SociVersion}/soci-snapshotter-${SociVersion}-linux-arm64.tar.gz
-                - tar xvzf soci-snapshotter-${SociVersion}-linux-arm64.tar.gz soci
+                - tar xvzf soci-snapshotter-${SociVersion}-linux-arm64.tar.gz ./soci
                 - mv soci /usr/local/bin/soci
                 - echo Logging in to Amazon ECR...
                 - export PASSWORD=$(aws ecr get-login-password --region ${AWS::Region})
@@ -270,9 +270,8 @@ Resources:
               commands:
                 - cd api/
                 - echo Building the container image
-                - docker build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 .
-                - echo Export the container image
-                - docker save --output ./image.tar $IMAGE_URI:$IMAGE_TAG
+                - docker buildx create --driver=docker-container --use
+                - docker buildx build --quiet --tag $IMAGE_URI:$IMAGE_TAG --file Dockerfile.v2 --output type=docker,dest=./image.tar .
                 - echo Import the container image to containerd
                 - ctr image import ./image.tar
                 - echo Generating SOCI index


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bumped the SOCI version from 0.4.1 to 0.5.0
- Removed the workaround in place for arm64 as the CodeBuild images now support Buildx.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
